### PR TITLE
feat: switch config to orient routing around the routing system names

### DIFF
--- a/autoconfig.json
+++ b/autoconfig.json
@@ -1,34 +1,28 @@
 {
-  "AutoConfigVersion": 2025072301,
-  "AutoConfigSchema": 3,
-  "Bootstrap": [
-    "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-    "/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
-    "/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
-    "/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
-    "/dnsaddr/va1.bootstrap.libp2p.io/p2p/12D3KooWKnDdG3iXw9eTFijk3EWSunZcFi54Zka4wmtqtt6rPxc8",
-    "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
-    "/ip4/104.131.131.82/udp/4001/quic-v1/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
-  ],
+  "AutoConfigVersion": 2025072401,
+  "AutoConfigSchema": 4,
   "DNSResolvers": {
     "eth.": [
       "https://dns.eth.limo/dns-query",
       "https://dns.eth.link/dns-query"
     ]
   },
-  "DelegatedRouters": {
-    "mainnet-for-nodes-with-dht": [
-      "https://cid.contact/routing/v1/providers"
-    ],
-    "mainnet-for-nodes-without-dht": [
-      "https://delegated-ipfs.dev/routing/v1/providers",
-      "https://delegated-ipfs.dev/routing/v1/peers",
-      "https://delegated-ipfs.dev/routing/v1/ipns"
-    ]
-  },
-  "DelegatedPublishers": {
-    "mainnet-for-ipns-publishers-with-http": [
-      "https://delegated-ipfs.dev/routing/v1/ipns"
-    ]
+  "Routing" : {
+    "Systems" : [ "AminoDHT", "IPNI"],
+    "DelegatedRouters" : {
+          "https://cid.contact" : ["IPNI"],
+          "https://delegated-ipfs.dev" : ["AminoDHT", "IPNI"]
+    },
+    "AminoDHT" : {
+      "Boostrap" : [
+        "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+        "/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
+        "/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+        "/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
+        "/dnsaddr/va1.bootstrap.libp2p.io/p2p/12D3KooWKnDdG3iXw9eTFijk3EWSunZcFi54Zka4wmtqtt6rPxc8",
+        "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+        "/ip4/104.131.131.82/udp/4001/quic-v1/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
+        ]
+    }
   }
 }


### PR DESCRIPTION
@lidel putting up an alternative proposal for the config formatting to discuss 

While we both have gripes about the state of the kubo config for routing, I feel like this setup is really quite coupled to what kubo looks like right now.

The overall idea of the change is to:
- Have close to the minimum data needed given existing types of usage
- Be more easily extensible for people to add new systems (e.g. someone can add "NewSys" to their list of systems and give it a delegated routing endpoint and implementations will just add unless they already have a specific "NewSys" implementation)

I'll drop more comments on the individual changes made for easier discussion