### PR TITLE
refactor: schema 4 with extensible systems and APIs

### DIFF
--- a/autoconfig.json
+++ b/autoconfig.json
@@ -1,34 +1,119 @@
 {
-  "AutoConfigVersion": 2025072301,
-  "AutoConfigSchema": 3,
-  "Bootstrap": [
-    "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
-    "/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
-    "/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
-    "/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
-    "/dnsaddr/va1.bootstrap.libp2p.io/p2p/12D3KooWKnDdG3iXw9eTFijk3EWSunZcFi54Zka4wmtqtt6rPxc8",
-    "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
-    "/ip4/104.131.131.82/udp/4001/quic-v1/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
-  ],
+  "AutoConfigVersion": 2025072801,
+  "AutoConfigSchema": 4,
+  "CacheTTL": 86400,
+  "SystemRegistry": {
+    "AminoDHT": {
+      "URL": "https://github.com/ipfs/specs/pull/497",
+      "Description": "Public DHT swarm that implements the IPFS Kademlia DHT specification under protocol identifier /ipfs/kad/1.0.0",
+      "NativeConfig": {
+        "Bootstrap": [
+          "/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN",
+          "/dnsaddr/bootstrap.libp2p.io/p2p/QmQCU2EcMqAqQPR2i9bChDtGNJchTbq5TbXJJ16u19uLTa",
+          "/dnsaddr/bootstrap.libp2p.io/p2p/QmbLHAnMoJPWSCR5Zhtx6BHJX9KiKNN6tpvbUcqanj75Nb",
+          "/dnsaddr/bootstrap.libp2p.io/p2p/QmcZf59bWwK5XFi76CZX8cbJ4BhTzzA3gU1ZjYZcYW3dwt",
+          "/dnsaddr/va1.bootstrap.libp2p.io/p2p/12D3KooWKnDdG3iXw9eTFijk3EWSunZcFi54Zka4wmtqtt6rPxc8",
+          "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
+          "/ip4/104.131.131.82/udp/4001/quic-v1/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
+        ]
+      },
+      "DelegatedConfig": {
+        "Read": [
+          "/routing/v1/providers",
+          "/routing/v1/peers",
+          "/routing/v1/ipns"
+        ],
+        "Write": []
+      }
+    },
+    "IPNI": {
+      "URL": "https://cid.contact",
+      "Description": "Network Indexer - content routing database for large storage providers",
+      "DelegatedConfig": {
+        "Read": [
+          "/routing/v1/providers"
+        ],
+        "Write": []
+      }
+    },
+    "IPNS": {
+      "URL": "https://specs.ipfs.tech/ipns/ipns-record/",
+      "Description": "InterPlanetary Name System - signed mutable records that point to CIDs with optional metadata",
+      "DelegatedConfig": {
+        "Read": [
+          "/routing/v1/ipns"
+        ],
+        "Write": [
+          "/routing/v1/ipns"
+        ]
+      }
+    },
+    "DNS": {
+      "URL": "https://datatracker.ietf.org/doc/html/rfc8484",
+      "Description": "DNS over HTTPS (DoH) - protocol for performing DNS resolution via the HTTPS protocol",
+      "DelegatedConfig": {
+        "Read": [
+          "/dns-query"
+        ],
+        "Write": []
+      }
+    },
+    "Example": {
+      "URL": "https://example.com",
+      "Description": "Example routing system demonstrating extensibility. Clients should ignore unknown APIs they don't recognize",
+      "DelegatedConfig": {
+        "Read": [
+          "/example/v0/read"
+        ],
+        "Write": [
+          "/example/v0/write"
+        ]
+      }
+    }
+  },
   "DNSResolvers": {
     "eth.": [
       "https://dns.eth.limo/dns-query",
       "https://dns.eth.link/dns-query"
     ]
   },
-  "DelegatedRouters": {
-    "mainnet-for-nodes-with-dht": [
-      "https://cid.contact/routing/v1/providers"
-    ],
-    "mainnet-for-nodes-without-dht": [
-      "https://delegated-ipfs.dev/routing/v1/providers",
-      "https://delegated-ipfs.dev/routing/v1/peers",
-      "https://delegated-ipfs.dev/routing/v1/ipns"
-    ]
+  "DelegatedEndpoints": {
+    "https://cid.contact": {
+      "Systems": ["IPNI"],
+      "Read": [
+        "/routing/v1/providers"
+      ],
+      "Write": []
+    },
+    "https://delegated-ipfs.dev": {
+      "Systems": ["AminoDHT", "IPNI", "IPNS", "DNS"],
+      "Read": [
+        "/routing/v1/providers",
+        "/routing/v1/peers",
+        "/routing/v1/ipns",
+        "/dns-query"
+      ],
+      "Write": [
+        "/routing/v1/ipns"
+      ]
+    },
+    "https://example.com": {
+      "Systems": ["Example"],
+      "Read": [
+        "/example/v0/read"
+      ],
+      "Write": [
+        "/example/v0/write"
+      ]
+    }
   },
-  "DelegatedPublishers": {
-    "mainnet-for-ipns-publishers-with-http": [
-      "https://delegated-ipfs.dev/routing/v1/ipns"
-    ]
+  "Profiles": {
+    "browser": {
+      "PreferDelegated": ["AminoDHT", "IPNI", "IPNS", "DNS"]
+    },
+    "daemon": {
+      "PreferNative": ["AminoDHT", "IPNS", "DNS"],
+      "PreferDelegated": ["IPNI"]
+    }
   }
 }

--- a/autoconfig.json
+++ b/autoconfig.json
@@ -40,7 +40,7 @@
     },
     "Example": {
       "URL": "https://example.com",
-      "Description": "Example routing system demonstrating extensibility. Clients should ignore unknown APIs they don't recognize",
+      "Description": "Test system for implementers to verify graceful handling of unknown systems and APIs. Production clients MUST ignore this system and its /example/* endpoints without errors.",
       "DelegatedConfig": {
         "Read": [
           "/example/v0/read"

--- a/autoconfig.json
+++ b/autoconfig.json
@@ -1,5 +1,5 @@
 {
-  "AutoConfigVersion": 2025072801,
+  "AutoConfigVersion": 2025072901,
   "AutoConfigSchema": 4,
   "CacheTTL": 86400,
   "SystemRegistry": {
@@ -48,16 +48,6 @@
         ]
       }
     },
-    "DNS": {
-      "URL": "https://datatracker.ietf.org/doc/html/rfc8484",
-      "Description": "DNS over HTTPS (DoH) - protocol for performing DNS resolution via the HTTPS protocol",
-      "DelegatedConfig": {
-        "Read": [
-          "/dns-query"
-        ],
-        "Write": []
-      }
-    },
     "Example": {
       "URL": "https://example.com",
       "Description": "Example routing system demonstrating extensibility. Clients should ignore unknown APIs they don't recognize",
@@ -86,12 +76,11 @@
       "Write": []
     },
     "https://delegated-ipfs.dev": {
-      "Systems": ["AminoDHT", "IPNI", "IPNS", "DNS"],
+      "Systems": ["AminoDHT", "IPNI", "IPNS"],
       "Read": [
         "/routing/v1/providers",
         "/routing/v1/peers",
-        "/routing/v1/ipns",
-        "/dns-query"
+        "/routing/v1/ipns"
       ],
       "Write": [
         "/routing/v1/ipns"
@@ -109,10 +98,10 @@
   },
   "Profiles": {
     "browser": {
-      "PreferDelegated": ["AminoDHT", "IPNI", "IPNS", "DNS"]
+      "PreferDelegated": ["AminoDHT", "IPNI", "IPNS"]
     },
     "daemon": {
-      "PreferNative": ["AminoDHT", "IPNS", "DNS"],
+      "PreferNative": ["AminoDHT", "IPNS"],
       "PreferDelegated": ["IPNI"]
     }
   }

--- a/autoconfig.json
+++ b/autoconfig.json
@@ -85,14 +85,5 @@
         "/example/v0/write"
       ]
     }
-  },
-  "Profiles": {
-    "browser": {
-      "PreferDelegated": ["AminoDHT", "IPNI"]
-    },
-    "daemon": {
-      "PreferNative": ["AminoDHT"],
-      "PreferDelegated": ["IPNI"]
-    }
   }
 }

--- a/autoconfig.json
+++ b/autoconfig.json
@@ -23,7 +23,9 @@
           "/routing/v1/peers",
           "/routing/v1/ipns"
         ],
-        "Write": []
+        "Write": [
+          "/routing/v1/ipns"
+        ]
       }
     },
     "IPNI": {
@@ -34,18 +36,6 @@
           "/routing/v1/providers"
         ],
         "Write": []
-      }
-    },
-    "IPNS": {
-      "URL": "https://specs.ipfs.tech/ipns/ipns-record/",
-      "Description": "InterPlanetary Name System - signed mutable records that point to CIDs with optional metadata",
-      "DelegatedConfig": {
-        "Read": [
-          "/routing/v1/ipns"
-        ],
-        "Write": [
-          "/routing/v1/ipns"
-        ]
       }
     },
     "Example": {
@@ -76,7 +66,7 @@
       "Write": []
     },
     "https://delegated-ipfs.dev": {
-      "Systems": ["AminoDHT", "IPNI", "IPNS"],
+      "Systems": ["AminoDHT", "IPNI"],
       "Read": [
         "/routing/v1/providers",
         "/routing/v1/peers",
@@ -98,10 +88,10 @@
   },
   "Profiles": {
     "browser": {
-      "PreferDelegated": ["AminoDHT", "IPNI", "IPNS"]
+      "PreferDelegated": ["AminoDHT", "IPNI"]
     },
     "daemon": {
-      "PreferNative": ["AminoDHT", "IPNS"],
+      "PreferNative": ["AminoDHT"],
       "PreferDelegated": ["IPNI"]
     }
   }

--- a/index.html
+++ b/index.html
@@ -451,8 +451,7 @@
                 <ol class="process-steps">
                     <li><strong>Extensibility:</strong> Unknown APIs are safely ignored, allowing gradual ecosystem evolution</li>
                     <li><strong>Endpoint-Level Capabilities:</strong> Each endpoint declares exactly which APIs it supports</li>
-                    <li><strong>Profile Guidance:</strong> Optional hints for browser vs daemon environments without enforcement</li>
-                    <li><strong>24-Hour Caching:</strong> Clients cache configurations locally with automatic refresh</li>
+                    <li><strong>Configurable Caching:</strong> Clients cache configurations locally based on CacheTTL with a maximum of 24 hours</li>
                 </ol>
             </div>
         </section>
@@ -480,8 +479,8 @@
                     <div class="config-section">
                         <h4><code>CacheTTL</code></h4>
                         <p><strong>Purpose:</strong> Cache duration in seconds</p>
-                        <p><strong>Usage:</strong> A hint that clients should cache config for this duration, clients can override this hint but only as explicit user opt-in</p>
-                        <p><strong>Value:</strong> <code>86400</code> (24 hours)</p>
+                        <p><strong>Usage:</strong> A hint that clients should cache config for this duration (capped at 24 hours maximum), clients can override this hint but only as explicit user opt-in</p>
+                        <p><strong>Default:</strong> <code>86400</code> (24 hours)</p>
                     </div>
 
                     <div class="config-section">
@@ -506,12 +505,6 @@
                         <p><strong>Usage:</strong> Clients use these when they don't have native system support</p>
                     </div>
 
-                    <div class="config-section">
-                        <h4><code>Profiles</code></h4>
-                        <p><strong>Purpose:</strong> Optional guidance for different client environments</p>
-                        <p><strong>Types:</strong> Browser (prefer delegated) vs Daemon (prefer native)</p>
-                        <p><strong>Usage:</strong> Implementations can use as hints but make their own decisions</p>
-                    </div>
                 </div>
 
             </div>
@@ -635,36 +628,8 @@
                     <li><strong>Backward compatibility:</strong> Older clients continue working, simply ignoring systems they don't recognize</li>
                 </ul>
 
-                <h3>Client Implementation Logic</h3>
-                <p>Here's how clients should process the configuration:</p>
-
-                <div class="code-block">
-                    <div class="code-header">Client Processing Algorithm</div>
-                    <pre>// 1. Check SystemRegistry for available routing systems
-for system in autoconfig.SystemRegistry:
-    if client.supportsNative(system):
-        // Use native implementation with NativeConfig
-        client.configureNative(system, autoconfig.SystemRegistry[system].NativeConfig)
-    else:
-        // Use delegated routing via HTTP endpoints
-        for endpoint in autoconfig.DelegatedEndpoints:
-            if system in endpoint.Systems:
-                // Filter to only APIs this client recognizes
-                supportedReadAPIs = client.filterKnownAPIs(endpoint.Read)
-                supportedWriteAPIs = client.filterKnownAPIs(endpoint.Write)
-                // Configure delegated routing using only supported APIs
-                client.configureDelegated(system, endpoint, supportedReadAPIs, supportedWriteAPIs)
-
-// 2. Apply profile preferences (optional)
-profile = detectEnvironment() // "browser" or "daemon"
-if autoconfig.Profiles[profile]:
-    client.applyPreferences(autoconfig.Profiles[profile])
-
-// 3. Configure DNS resolvers for special TLDs
-// Note: Implementations use OS default or explicit DoH resolver
-for etld, resolvers in autoconfig.DNSResolvers:
-    client.configureDNS(etld, resolvers)</pre>
-                </div>
+                <h3>Client Implementation</h3>
+                <p>Clients should process the configuration by checking available systems, determining native vs delegated routing support, and configuring DNS resolvers for special TLDs.</p>
 
                 <h3>API Versioning Strategy</h3>
                 <p>Delegated utility servers can support multiple API versions simultaneously:</p>
@@ -716,8 +681,31 @@ for etld, resolvers in autoconfig.DNSResolvers:
                     </div>
                 </div>
 
-                <h3>Example Implementation</h3>
-                <p>Here's a simplified example of how a client might consume this configuration:</p>
+                <h4>Processing Algorithm</h4>
+                <div class="code-block">
+                    <div class="code-header">Pseudo-code</div>
+                    <pre>// 1. Check SystemRegistry for available routing systems
+for system in autoconfig.SystemRegistry:
+    if client.supportsNative(system):
+        // Use native implementation with NativeConfig
+        client.configureNative(system, autoconfig.SystemRegistry[system].NativeConfig)
+    else:
+        // Use delegated routing via HTTP endpoints
+        for endpoint in autoconfig.DelegatedEndpoints:
+            if system in endpoint.Systems:
+                // Filter to only APIs this client recognizes
+                supportedReadAPIs = client.filterKnownAPIs(endpoint.Read)
+                supportedWriteAPIs = client.filterKnownAPIs(endpoint.Write)
+                // Configure delegated routing using only supported APIs
+                client.configureDelegated(system, endpoint, supportedReadAPIs, supportedWriteAPIs)
+
+// 2. Configure DNS resolvers for special TLDs
+// Note: Implementations use OS default or explicit DoH resolver
+for etld, resolvers in autoconfig.DNSResolvers:
+    client.configureDNS(etld, resolvers)</pre>
+                </div>
+
+                <h4>Example Implementation</h4>
 
                 <div class="code-block">
                     <div class="code-header">JavaScript Client Example</div>
@@ -726,10 +714,12 @@ for etld, resolvers in autoconfig.DNSResolvers:
     const response = await fetch('https://config.ipfs-mainnet.org/autoconfig.json');
     const autoconfig = await response.json();
     
-    // Cache for 24 hours
+    // Cache for minimum of 24 hours or CacheTTL from config
+    const maxCacheSeconds = 24 * 60 * 60; // 24 hours
+    const cacheTTL = Math.min(maxCacheSeconds, autoconfig.CacheTTL || maxCacheSeconds);
     localStorage.setItem('ipfs-autoconfig', JSON.stringify({
         data: autoconfig,
-        expires: Date.now() + (autoconfig.CacheTTL * 1000)
+        expires: Date.now() + (cacheTTL * 1000)
     }));
     
     // Define which systems this client supports natively
@@ -759,6 +749,92 @@ for etld, resolvers in autoconfig.DNSResolvers:
     }
 }</pre>
                 </div>
+
+                <h3>Implementation Guidance</h3>
+                <p>Different IPFS implementations have different constraints and capabilities. Here are recommendations for common deployment scenarios:</p>
+
+                <div class="feature-grid">
+                    <div class="feature-card">
+                        <h4>🌐 Browser Implementations</h4>
+                        <p><strong>Constraints:</strong> Limited networking, no raw sockets, CORS restrictions</p>
+                        <p><strong>Recommendations:</strong></p>
+                        <ul style="text-align: left; padding-left: 1.5rem;">
+                            <li>Prefer delegated routing for all systems</li>
+                            <li>Use HTTPS endpoints exclusively</li>
+                            <li>Implement aggressive caching</li>
+                            <li>Consider service worker integration</li>
+                        </ul>
+                        <div class="code-block" style="margin-top: 1rem;">
+                            <pre style="text-align: left;">// Browser-optimized configuration
+const browserDefaults = {
+    preferDelegated: ['AminoDHT', 'IPNI'],
+    enableNative: [] // No native routing in browsers
+};</pre>
+                        </div>
+                    </div>
+
+                    <div class="feature-card">
+                        <h4>🖥️ Daemon Implementations</h4>
+                        <p><strong>Capabilities:</strong> Full networking, persistent storage, background processing</p>
+                        <p><strong>Recommendations:</strong></p>
+                        <ul style="text-align: left; padding-left: 1.5rem;">
+                            <li>Prefer native DHT participation</li>
+                            <li>Use delegated routing for specialized systems (IPNI)</li>
+                            <li>Enable both TCP and QUIC transports</li>
+                            <li>Participate in content providing (native AminoDHT only)</li>
+                        </ul>
+                        <div class="code-block" style="margin-top: 1rem;">
+                            <pre style="text-align: left;">// Daemon-optimized configuration
+const daemonDefaults = {
+    preferNative: ['AminoDHT'],
+    preferDelegated: ['IPNI'],
+    enableProviding: true // Only works with native AminoDHT
+};</pre>
+                        </div>
+                    </div>
+
+                    <div class="feature-card">
+                        <h4>📱 Mobile/Resource-Constrained</h4>
+                        <p><strong>Constraints:</strong> Battery life, bandwidth limits, intermittent connectivity</p>
+                        <p><strong>Recommendations:</strong></p>
+                        <ul style="text-align: left; padding-left: 1.5rem;">
+                            <li>Hybrid approach based on network type</li>
+                            <li>Delegated routing on cellular</li>
+                            <li>Optional native DHT on WiFi</li>
+                            <li>Aggressive connection pruning</li>
+                        </ul>
+                        <div class="code-block" style="margin-top: 1rem;">
+                            <pre style="text-align: left;">// Mobile-optimized configuration
+const mobileDefaults = {
+    preferDelegated: ['AminoDHT', 'IPNI'],
+    enableNativeOnWifi: ['AminoDHT'],
+    maxConnections: 50
+};</pre>
+                        </div>
+                    </div>
+                </div>
+
+                <h4>Platform-Specific Considerations</h4>
+                <p>Implementers should make these decisions at build time based on their target platform rather than reading them from the autoconfig. The autoconfig provides the <em>what</em> (available systems and endpoints), while your implementation decides the <em>how</em> (native vs delegated routing).</p>
+
+                <div class="code-block">
+                    <div class="code-header">Implementation Decision Tree</div>
+                    <pre>// Instead of reading profiles from autoconfig, hard-code platform decisions:
+function getRoutingStrategy() {
+    if (typeof window !== 'undefined' && !window.require) {
+        // Browser environment
+        return { preferDelegated: true };
+    } else if (process.env.IPFS_LITE_MODE) {
+        // Resource-constrained environment
+        return { preferDelegated: true, maxConnections: 50 };
+    } else {
+        // Full daemon environment
+        return { preferNative: true, enableProviding: true }; // Providing requires native AminoDHT
+    }
+}</pre>
+                </div>
+
+                <p>This approach provides clearer separation between configuration data (what services are available) and implementation decisions (how to use those services), making both the autoconfig and implementations simpler and more maintainable.</p>
             </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>IPFS Mainnet AutoConfig - Dynamic Configuration for IPFS Mainnet Swarm</title>
-    <meta name="description" content="IPFS Mainnet AutoConfig hosts dynamic configuration for bootstrap peers, DNS resolvers, and routing endpoints in the IPFS Mainnet swarm.">
+    <title>🧭 IPFS Mainnet AutoConfig - Dynamic Configuration for IPFS Mainnet Swarm</title>
+    <meta name="description" content="IPFS Mainnet AutoConfig hosts dynamic configuration for routing systems, bootstrap peers, DNS resolvers, and delegated endpoints in the IPFS Mainnet swarm.">
     <style>
         * {
             margin: 0;
@@ -75,8 +75,16 @@
 
         h3 {
             color: #333;
+            margin-bottom: 1rem;
+            font-size: 1.5rem;
+            font-weight: 600;
+        }
+
+        h4 {
+            color: #333;
             margin-bottom: 0.5rem;
             font-size: 1.25rem;
+            font-weight: 600;
         }
 
         p {
@@ -200,6 +208,7 @@
             border: 1px solid #e2e8f0;
             border-radius: 0.5rem;
             overflow-x: auto;
+            margin: 1.5rem 0;
         }
 
         .code-header {
@@ -219,7 +228,7 @@
 
         .config-sections {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
             gap: 1.5rem;
             margin: 2rem 0;
         }
@@ -255,34 +264,6 @@
 
         .process-steps li::before {
             content: counter(step-counter);
-            position: absolute;
-            left: 0;
-            top: 0;
-            background: #e2e8f0;
-            color: #4a5568;
-            width: 1.75rem;
-            height: 1.75rem;
-            border-radius: 50%;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            font-size: 0.875rem;
-            font-weight: bold;
-        }
-
-        .question-steps {
-            counter-reset: none;
-            list-style: none;
-        }
-
-        .question-steps li {
-            margin-bottom: 1.5rem;
-            padding-left: 3rem;
-            position: relative;
-        }
-
-        .question-steps li::before {
-            content: "?";
             position: absolute;
             left: 0;
             top: 0;
@@ -351,6 +332,24 @@
             font-size: 1rem;
         }
 
+        code {
+            background: #f7fafc;
+            color: #2d3748;
+            padding: 0.125rem 0.25rem;
+            border-radius: 0.25rem;
+            font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+            font-size: 0.875rem;
+        }
+
+        ul, ol {
+            margin-bottom: 1rem;
+            padding-left: 2rem;
+        }
+
+        li {
+            margin-bottom: 0.5rem;
+        }
+
         footer {
             background: #2d3748;
             color: white;
@@ -369,20 +368,6 @@
 
         footer a:hover {
             color: white;
-        }
-
-        .footer-content {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-            gap: 2rem;
-        }
-
-        .footer-content ul {
-            list-style: none;
-        }
-
-        .footer-content li {
-            margin-bottom: 0.5rem;
         }
 
         .footer-bottom {
@@ -420,12 +405,12 @@
     </div>
     <header>
         <nav class="container">
-            <h1>IPFS Mainnet AutoConfig</h1>
+            <h1>🧭 IPFS Mainnet AutoConfig</h1>
             <ul class="nav-links">
                 <li><a href="#overview">Overview</a></li>
-                <li><a href="#autoconfig">AutoConfig</a></li>
-                <li><a href="#profiles">Mainnet Profiles</a></li>
-                <li><a href="#implementation">Implementation</a></li>
+                <li><a href="#schema">Format</a></li>
+                <li><a href="#systems">Systems</a></li>
+                <li><a href="#implementation">Implementations</a></li>
             </ul>
         </nav>
     </header>
@@ -434,7 +419,7 @@
         <section class="hero">
             <div class="container">
                 <h2>Dynamic Configuration<br>for IPFS Mainnet</h2>
-                <p class="lead">Updateable swarm-specific defaults for Bootstrap peers, DNS resolvers, Delegated Routing and more.</p>
+                <p class="lead">Updateable system registry for routing systems, bootstrap peers, DNS resolvers, and delegated endpoints.</p>
                 <div class="url-input-group">
                     <input type="text" class="url-input" value="https://config.ipfs-mainnet.org/autoconfig.json" readonly>
                     <button class="btn-secondary" onclick="copyUrl()">Copy</button>
@@ -449,120 +434,268 @@
         <section id="overview">
             <div class="container">
                 <h2>Overview</h2>
-                <p>This page hosts the AutoConfig JSON for IPFS Mainnet, providing dynamic network defaults that can be updated independently of software releases.</p>
-
-                <h3>What is Mainnet?</h3>
-                <p>IPFS Mainnet is the default public network that most IPFS implementations connect to. It joins the Amino DHT and queries Delegated Routing endpoints for content routing, uses Bootstrap nodes to enter the network, relies on DNS resolvers for DNSLink and DNSAddr resolution, uses Bitswap and trustless HTTP for data transfer, and uses UnixFS for encoding files and directories. This configuration provides the standard interoperability layer for the shared public swarm IPFS ecosystem.</p>
+                <p>IPFS Mainnet AutoConfig provides a standardized, extensible configuration format for IPFS implementations to discover and configure routing systems, bootstrap peers, DNS resolvers, and delegated endpoints dynamically.</p>
 
                 <h3>What is AutoConfig?</h3>
-                <p>IPFS nodes have historically relied on hardcoded defaults for Bootstrap peers, DNS resolvers, and Delegated Routing endpoints. This required software updates to change swarm defaults and made it difficult to adapt to swarm changes.</p>
+                <p>This version introduces a system-centric approach that moves away from hardcoded profiles to a flexible registry where routing systems declare their capabilities and endpoints specify which systems they support. This enables:</p>
+                
+                <ul>
+                    <li><strong>Dynamic System Discovery:</strong> New routing systems can be added without breaking existing clients</li>
+                    <li><strong>Future-Proof API Versioning:</strong> Endpoints can support multiple API versions simultaneously</li>
+                    <li><strong>Clear Separation:</strong> Native configuration (bootstrap peers) vs delegated configuration (HTTP endpoints)</li>
+                    <li><strong>Client Choice:</strong> Implementations decide whether to use native or delegated routing per system</li>
+                    <li><strong>API Compatibility:</strong> Clients ignore unknown APIs and use only the endpoints they understand</li>
+                </ul>
 
-                <p>AutoConfig convention moves these defaults to a configurable URL for a JSON file that can be updated independently, enabling real-time updates while preserving user agency through full customization options.</p>
-
-                <p>AutoConfig enables dynamic swarm defaults through:</p>
+                <h3>Key Principles</h3>
                 <ol class="process-steps">
-                    <li><strong>Explicit Setup:</strong> New IPFS nodes use "auto" placeholders instead of silently hardcoded strings in source code</li>
-                    <li><strong>Dynamic Updates:</strong> IPFS nodes automatically fetch the latest swarm defaults on startup, save them locally for offline use, and can periodically check for updates without interrupting service</li>
-                    <li><strong>User Agency:</strong> Implementations respect user-set overrides, and users can also keep "auto" while appending their own bootstrap peers and other custom settings</li>
+                    <li><strong>Extensibility:</strong> Unknown APIs are safely ignored, allowing gradual ecosystem evolution</li>
+                    <li><strong>Endpoint-Level Capabilities:</strong> Each endpoint declares exactly which APIs it supports</li>
+                    <li><strong>Profile Guidance:</strong> Optional hints for browser vs daemon environments without enforcement</li>
+                    <li><strong>24-Hour Caching:</strong> Clients cache configurations locally with automatic refresh</li>
                 </ol>
             </div>
         </section>
 
-        <section id="autoconfig">
+        <section id="schema">
             <div class="container">
-                <h2>AutoConfig Format</h2>
-
-                <h3>Path-Based Routing Configuration</h3>
-                <p>AutoConfig supports path-based routing URLs that automatically enable specific <a href="https://specs.ipfs.tech/routing/http-routing-v1/">HTTP Routing V1</a> operations based on the URL path. This enables precise, efficient routing where each endpoint URL automatically determines its capabilities:</p>
+                <h2>Configuration Format</h2>
+                <p>The AutoConfig format consists of six main sections that work together to provide comprehensive routing configuration:</p>
 
                 <div class="config-sections">
                     <div class="config-section">
-                        <h4>Supported Routing Paths</h4>
-                        <ul>
-                            <li><code>/routing/v1/providers</code> - Provider record lookups</li>
-                            <li><code>/routing/v1/peers</code> - Peer routing lookups</li>
-                            <li><code>/routing/v1/ipns</code> - IPNS record operations</li>
-                            <li><em>No path</em> - All routing operations</li>
-                        </ul>
+                        <h4><code>AutoConfigVersion</code></h4>
+                        <p><strong>Purpose:</strong> Timestamp-based version identifier (YYYYMMDDNN format), similar to DNS SOA sequence numbers</p>
+                        <p><strong>Usage:</strong> Clients use this to determine if they have the latest configuration</p>
+                        <p><strong>Example:</strong> <code>2025072801</code> (January 28, 2025, version 01)</p>
                     </div>
+
                     <div class="config-section">
-                        <h4>AutoConfig Schema</h4>
-                        <ul>
-                            <li><code>Bootstrap</code> - Network bootstrap peers</li>
-                            <li><code>DNSResolvers</code> - DNS resolution endpoints</li>
-                            <li><code>DelegatedRouters</code> - Content routing endpoints</li>
-                            <li><code>DelegatedPublishers</code> - IPNS publishing endpoints</li>
-                        </ul>
+                        <h4><code>AutoConfigSchema</code></h4>
+                        <p><strong>Purpose:</strong> Schema version number for breaking changes</p>
+                        <p><strong>Usage:</strong> Allows clients to handle different config formats</p>
+                        <p><strong>Current:</strong> <code>4</code></p>
+                    </div>
+
+                    <div class="config-section">
+                        <h4><code>CacheTTL</code></h4>
+                        <p><strong>Purpose:</strong> Cache duration in seconds</p>
+                        <p><strong>Usage:</strong> A hint that clients should cache config for this duration, clients can override this hint but only as explicit user opt-in</p>
+                        <p><strong>Value:</strong> <code>86400</code> (24 hours)</p>
+                    </div>
+
+                    <div class="config-section">
+                        <h4><code>SystemRegistry</code></h4>
+                        <p><strong>Purpose:</strong> Discovery registry of all routing systems</p>
+                        <p><strong>Contains:</strong> System metadata, native configuration, and delegated API capabilities</p>
+                        <p><strong>Usage:</strong> Clients check here to understand system capabilities</p>
+                    </div>
+
+                    <div class="config-section">
+                        <h4><code>DNSResolvers</code></h4>
+                        <p><strong>Purpose:</strong> DNS-over-HTTPS resolvers organized by effective TLD</p>
+                        <p><strong>Usage:</strong> Resolving non-ICANN domains</p>
+                        <p><strong>Format:</strong> Maps eTLD to array of DoH endpoints</p>
+                    </div>
+
+                    <div class="config-section">
+                        <h4><code>DelegatedEndpoints</code></h4>
+                        <p><strong>Purpose:</strong> HTTP endpoints that provide routing services via delegation</p>
+                        <p><strong>Contains:</strong> Endpoint URL, supported systems, Read/Write API paths</p>
+                        <p><strong>Usage:</strong> Clients use these when they don't have native system support</p>
+                    </div>
+
+                    <div class="config-section">
+                        <h4><code>Profiles</code></h4>
+                        <p><strong>Purpose:</strong> Optional guidance for different client environments</p>
+                        <p><strong>Types:</strong> Browser (prefer delegated) vs Daemon (prefer native)</p>
+                        <p><strong>Usage:</strong> Implementations can use as hints but make their own decisions</p>
                     </div>
                 </div>
+
             </div>
         </section>
 
-        <section id="profiles">
+        <section id="systems">
             <div class="container">
-                <h2>Mainnet Profiles</h2>
-                <p>IPFS Mainnet AutoConfig provides specific configuration profiles optimized for different node types and use cases. Each profile defines appropriate routing strategies based on node capabilities and requirements.</p>
+                <h2>Well Known Routing Systems</h2>
+                <p>The registry defines routing systems with their capabilities and access methods:</p>
 
-                <h3>Available Profiles</h3>
-                <p>Each profile is designed for specific node characteristics and use cases:</p>
+                <style>
+                    .systems-table {
+                        width: 100%;
+                        border-collapse: collapse;
+                        margin: 1.5rem 0;
+                        background: #f8f9fa;
+                        border-radius: 0.5rem;
+                        overflow: hidden;
+                    }
+                    .systems-table th {
+                        background: #e9ecef;
+                        padding: 0.75rem;
+                        text-align: left;
+                        font-weight: 600;
+                        border-bottom: 2px solid #dee2e6;
+                    }
+                    .systems-table td {
+                        padding: 0.75rem;
+                        border-bottom: 1px solid #e9ecef;
+                    }
+                    .systems-table tr:last-child td {
+                        border-bottom: none;
+                    }
+                    .system-name {
+                        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+                        font-weight: 600;
+                        color: #2d3748;
+                    }
+                    .system-type {
+                        display: inline-block;
+                        padding: 0.2rem 0.5rem;
+                        border-radius: 0.25rem;
+                        font-size: 0.75rem;
+                        font-weight: 600;
+                    }
+                    .type-native {
+                        background: #d1fae5;
+                        color: #065f46;
+                    }
+                    .type-delegated {
+                        background: #dbeafe;
+                        color: #1e40af;
+                    }
+                    .type-both {
+                        background: #fef3c7;
+                        color: #92400e;
+                    }
+                    .api-list {
+                        font-family: 'Monaco', 'Menlo', 'Ubuntu Mono', monospace;
+                        font-size: 0.75rem;
+                        color: #4a5568;
+                    }
+                </style>
 
-                <div class="config-sections">
-                    <div class="config-section">
-                        <h4><code>mainnet-for-nodes-with-dht</code></h4>
-                        <p><strong>Purpose:</strong> For full IPFS nodes that actively participate in the Amino DHT network.</p>
-                        <p><strong>Characteristics:</strong> These are typically long-running, well-connected nodes (servers, desktop applications) that contribute to the DHT by storing routing records and responding to queries.</p>
-                        <p><strong>Routing Strategy:</strong> Primarily uses DHT for routing operations but supplements with delegated routing for content provider lookups to improve discovery performance.</p>
-                        <p><strong>Typical Use Cases:</strong> Kubo nodes, Rainbow gateways, IPFS Cluster nodes, always-on infrastructure nodes.</p>
+                <table class="systems-table">
+                    <thead>
+                        <tr>
+                            <th>System</th>
+                            <th>Type</th>
+                            <th>Purpose</th>
+                            <th>APIs</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><a href="https://github.com/ipfs/specs/pull/497" class="system-name">AminoDHT</a></td>
+                            <td><span class="system-type type-both">Native + Delegated</span></td>
+                            <td>P2P content and peer routing via Kademlia DHT</td>
+                            <td class="api-list">/routing/v1/{providers,peers,ipns}</td>
+                        </tr>
+                        <tr>
+                            <td><a href="https://cid.contact" class="system-name">IPNI</a></td>
+                            <td><span class="system-type type-delegated">Delegated Only</span></td>
+                            <td>Fast content discovery from large storage providers</td>
+                            <td class="api-list">/routing/v1/providers</td>
+                        </tr>
+                        <tr>
+                            <td><a href="https://specs.ipfs.tech/ipns/ipns-record/" class="system-name">IPNS</a></td>
+                            <td><span class="system-type type-both">Native + Delegated</span></td>
+                            <td>Mutable name records pointing to CIDs</td>
+                            <td class="api-list">/routing/v1/ipns (R/W)</td>
+                        </tr>
+                        <tr>
+                            <td><a href="https://datatracker.ietf.org/doc/html/rfc8484" class="system-name">DNS</a></td>
+                            <td><span class="system-type type-both">Native + Delegated</span></td>
+                            <td>DNSLink and non-ICANN domain resolution</td>
+                            <td class="api-list">/dns-query</td>
+                        </tr>
+                        <tr>
+                            <td><a href="https://example.com" class="system-name">Example</a></td>
+                            <td><span class="system-type type-delegated">Delegated Only</span></td>
+                            <td>Demonstrates extensibility pattern</td>
+                            <td class="api-list">/example/v0/{read,write}</td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <h3>System Types</h3>
+                <div class="feature-grid">
+                    <div class="feature-card">
+                        <h4>🟢 Native</h4>
+                        <p>Direct implementation within the client (e.g., DHT participation, local DNS resolver)</p>
                     </div>
-                    <div class="config-section">
-                        <h4><code>mainnet-for-nodes-without-dht</code></h4>
-                        <p><strong>Purpose:</strong> For resource-constrained or ephemeral nodes that cannot effectively participate in the DHT.</p>
-                        <p><strong>Characteristics:</strong> These nodes have limited resources, connectivity constraints, or short session lifetimes that make DHT participation impractical or impossible.</p>
-                        <p><strong>Routing Strategy:</strong> Relies entirely on delegated routing services for all routing operations (content providers, peer discovery, IPNS resolution).</p>
-                        <p><strong>Typical Use Cases:</strong> Browser-based IPFS nodes, mobile applications, embedded devices, service worker gateways, Helia in resource-constrained environments.</p>
+                    <div class="feature-card">
+                        <h4>🔵 Delegated</h4>
+                        <p>Access via HTTP endpoints when native support is unavailable or impractical</p>
                     </div>
-                    <div class="config-section">
-                        <h4><code>mainnet-for-ipns-publishers-with-http</code></h4>
-                        <p><strong>Purpose:</strong> For nodes that need to publish IPNS records using HTTP routing endpoints rather than DHT.</p>
-                        <p><strong>Characteristics:</strong> These nodes may have DHT access limitations or prefer HTTP-based publishing for reliability, performance, or architectural reasons.</p>
-                        <p><strong>Routing Strategy:</strong> Uses HTTP routing endpoints specifically for IPNS record publishing operations. May be combined with other profiles for reading operations.</p>
-                        <p><strong>Typical Use Cases:</strong> Content publishing services, CI/CD systems, automated publishing workflows, nodes behind restrictive firewalls.</p>
+                    <div class="feature-card">
+                        <h4>🟡 Both</h4>
+                        <p>Systems that can operate either natively or through delegation based on client capabilities</p>
                     </div>
                 </div>
 
-                <h3>Choosing the Right Profile</h3>
-                <p>Select profiles based on your node's capabilities and requirements:</p>
-                <ol class="question-steps">
-                    <li><strong>Can your node participate in DHT?</strong> If yes, use <code>mainnet-for-nodes-with-dht</code> for optimal network contribution.</li>
-                    <li><strong>Is your node resource-constrained or short-lived?</strong> Use <code>mainnet-for-nodes-without-dht</code> for delegated routing dependency.</li>
-                    <li><strong>Do you need to publish IPNS via HTTP?</strong> Add <code>mainnet-for-ipns-publishers-with-http</code> for publishing capabilities.</li>
-                    <li><strong>Multiple profiles can be used together</strong> when nodes need different routing strategies for different operations.</li>
-                </ol>
+                <h3>Adding New Systems</h3>
+                <p>The schema supports gradual ecosystem evolution: add systems to the registry with their API paths, update endpoints to declare support, and existing clients will ignore unknown APIs while new clients can leverage them immediately.</p>
+                
+                <p>This extensibility mechanism allows IPFS Mainnet to introduce new routing systems by providing delegated HTTP adapters that existing software can understand and query. For example, a novel routing system can be deployed with HTTP endpoints that speak the standard routing protocols, enabling immediate adoption without requiring native implementation support from existing IPFS clients. This approach enables:</p>
+                
+                <ul>
+                    <li><strong>Zero-friction deployment:</strong> New systems work immediately with all existing IPFS implementations that support delegated routing</li>
+                    <li><strong>Gradual native adoption:</strong> Implementations can add native support over time while using delegation as a bridge</li>
+                    <li><strong>Innovation without fragmentation:</strong> Experimental routing systems can be tested in production without breaking compatibility</li>
+                    <li><strong>Backward compatibility:</strong> Older clients continue working, simply ignoring systems they don't recognize</li>
+                </ul>
+
+                <h3>Client Implementation Logic</h3>
+                <p>Here's how clients should process the configuration:</p>
 
                 <div class="code-block">
-                    <div class="code-header">Profile Configuration Example</div>
-                    <pre>{
-  "DelegatedRouters": {
-    // DHT-participating nodes: Supplement DHT with provider lookups
-    "mainnet-for-nodes-with-dht": [
-      "https://[endpoint]/routing/v1/providers"
-    ],
-    // Non-DHT nodes: Full delegated routing dependency
-    "mainnet-for-nodes-without-dht": [
-      "https://[endpoint]/routing/v1/providers",  // Content provider discovery
-      "https://[endpoint]/routing/v1/peers",      // Peer routing and discovery
-      "https://[endpoint]/routing/v1/ipns"        // IPNS record resolution
-    ]
-  },
-  "DelegatedPublishers": {
-    // HTTP IPNS publishing: Nodes that publish IPNS via HTTP routing
-    "mainnet-for-ipns-publishers-with-http": [
-      "https://[endpoint]/routing/v1/ipns"        // IPNS record publishing
-    ]
-  },
+                    <div class="code-header">Client Processing Algorithm</div>
+                    <pre>// 1. Check SystemRegistry for available routing systems
+for system in autoconfig.SystemRegistry:
+    if client.supportsNative(system):
+        // Use native implementation with NativeConfig
+        client.configureNative(system, autoconfig.SystemRegistry[system].NativeConfig)
+    else:
+        // Use delegated routing via HTTP endpoints
+        for endpoint in autoconfig.DelegatedEndpoints:
+            if system in endpoint.Systems:
+                // Filter to only APIs this client recognizes
+                supportedReadAPIs = client.filterKnownAPIs(endpoint.Read)
+                supportedWriteAPIs = client.filterKnownAPIs(endpoint.Write)
+                // Configure delegated routing using only supported APIs
+                client.configureDelegated(system, endpoint, supportedReadAPIs, supportedWriteAPIs)
 
-  // Additional AutoConfig sections (Bootstrap, DNSResolvers, etc.)
-  // are shared across all profiles and define common network defaults
+// 2. Apply profile preferences (optional)
+profile = detectEnvironment() // "browser" or "daemon"
+if autoconfig.Profiles[profile]:
+    client.applyPreferences(autoconfig.Profiles[profile])
+
+// 3. Configure DNS resolvers
+for etld, resolvers in autoconfig.DNSResolvers:
+    client.configureDNS(etld, resolvers)</pre>
+                </div>
+
+                <h3>API Versioning Strategy</h3>
+                <p>Delegated utility servers can support multiple API versions simultaneously:</p>
+
+                <div class="code-block">
+                    <div class="code-header">API Version Evolution Example</div>
+                    <pre>{
+  "DelegatedEndpoints": {
+    "https://future-endpoint.example": {
+      "Systems": ["AminoDHT", "NewSystem"],
+      "Read": [
+        "/routing/v1/providers",    // Legacy API
+        "/routing/v2/providers",    // Enhanced API
+        "/routing/v2/content"       // New capability
+      ],
+      "Write": [
+        "/routing/v1/ipns",         // Legacy publishing
+        "/routing/v2/ipns"          // Enhanced publishing
+      ]
+    }
+  }
 }</pre>
                 </div>
             </div>
@@ -570,11 +703,11 @@
 
         <section id="implementation">
             <div class="container">
-                <h2>Implementation Status</h2>
+                <h2>Implementations Status</h2>
                 <div class="status-banner">
                     <div>
                         <h3>🚧 Work in Progress</h3>
-                        <p>IPFS Mainnet AutoConfig support is under active development for integration into two main IPFS implementation ecosystems:</p>
+                        <p>IPFS Mainnet AutoConfig support is under active development for integration into IPFS implementation ecosystems:</p>
                         <div class="ecosystem-section">
                             <h4><a href="https://github.com/ipfs/boxo">Boxo</a> (Go ecosystem)</h4>
                             <ul>
@@ -591,6 +724,51 @@
                             </ul>
                         </div>
                     </div>
+                </div>
+
+                <h3>Example Implementation</h3>
+                <p>Here's a simplified example of how a client might consume this configuration:</p>
+
+                <div class="code-block">
+                    <div class="code-header">JavaScript Client Example</div>
+                    <pre>async function configureIPFS() {
+    // Fetch AutoConfig
+    const response = await fetch('https://config.ipfs-mainnet.org/autoconfig.json');
+    const autoconfig = await response.json();
+    
+    // Cache for 24 hours
+    localStorage.setItem('ipfs-autoconfig', JSON.stringify({
+        data: autoconfig,
+        expires: Date.now() + (autoconfig.CacheTTL * 1000)
+    }));
+    
+    // Define which systems this client supports natively
+    const nativeSystems = ['AminoDHT', 'IPNS']; // This client has native DHT and IPNS support
+    
+    // Configure routing systems
+    for (const [systemName, systemConfig] of Object.entries(autoconfig.SystemRegistry)) {
+        if (nativeSystems.includes(systemName)) {
+            // Use native implementation
+            if (systemName === 'AminoDHT' && canRunDHT()) {
+                configureNativeDHT(systemConfig.NativeConfig.Bootstrap);
+            } else if (systemName === 'IPNS') {
+                configureNativeIPNS(); // Native IPNS record handling
+            }
+        } else {
+            // Delegate to HTTP endpoints for unsupported systems
+            for (const [url, endpoint] of Object.entries(autoconfig.DelegatedEndpoints)) {
+                if (endpoint.Systems.includes(systemName)) {
+                    configureDelegatedRouting(systemName, url, endpoint);
+                }
+            }
+        }
+    }
+    
+    // Configure DNS resolvers
+    for (const [etld, resolvers] of Object.entries(autoconfig.DNSResolvers)) {
+        configureDNSResolver(etld, resolvers);
+    }
+}</pre>
                 </div>
             </div>
         </section>

--- a/index.html
+++ b/index.html
@@ -460,7 +460,7 @@
         <section id="schema">
             <div class="container">
                 <h2>Configuration Format</h2>
-                <p>The AutoConfig format consists of five main sections that work together to provide comprehensive routing configuration:</p>
+                <p>The AutoConfig format consists of the following sections that work together to provide comprehensive routing configuration:</p>
 
                 <div class="config-sections">
                     <div class="config-section">
@@ -590,19 +590,13 @@
                             <td><a href="https://github.com/ipfs/specs/pull/497" class="system-name">AminoDHT</a></td>
                             <td><span class="system-type type-both">Native + Delegated</span></td>
                             <td>P2P content and peer routing via Kademlia DHT</td>
-                            <td class="api-list">/routing/v1/{providers,peers,ipns}</td>
+                            <td class="api-list">/routing/v1/{providers,peers,ipns} (R/W for ipns)</td>
                         </tr>
                         <tr>
                             <td><a href="https://cid.contact" class="system-name">IPNI</a></td>
                             <td><span class="system-type type-delegated">Delegated Only</span></td>
                             <td>Fast content discovery from large storage providers</td>
                             <td class="api-list">/routing/v1/providers</td>
-                        </tr>
-                        <tr>
-                            <td><a href="https://specs.ipfs.tech/ipns/ipns-record/" class="system-name">IPNS</a></td>
-                            <td><span class="system-type type-both">Native + Delegated</span></td>
-                            <td>Mutable name records pointing to CIDs</td>
-                            <td class="api-list">/routing/v1/ipns (R/W)</td>
                         </tr>
                         <tr>
                             <td><a href="https://example.com" class="system-name">Example</a></td>
@@ -739,7 +733,7 @@ for etld, resolvers in autoconfig.DNSResolvers:
     }));
     
     // Define which systems this client supports natively
-    const nativeSystems = ['AminoDHT', 'IPNS']; // This client has native DHT and IPNS support
+    const nativeSystems = ['AminoDHT']; // This client has native DHT support
     
     // Configure routing systems
     for (const [systemName, systemConfig] of Object.entries(autoconfig.SystemRegistry)) {
@@ -747,8 +741,6 @@ for etld, resolvers in autoconfig.DNSResolvers:
             // Use native implementation
             if (systemName === 'AminoDHT' && canRunDHT()) {
                 configureNativeDHT(systemConfig.NativeConfig.Bootstrap);
-            } else if (systemName === 'IPNS') {
-                configureNativeIPNS(); // Native IPNS record handling
             }
         } else {
             // Delegate to HTTP endpoints for unsupported systems

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>🧭 IPFS Mainnet AutoConfig - Dynamic Configuration for IPFS Mainnet Swarm</title>
-    <meta name="description" content="IPFS Mainnet AutoConfig hosts dynamic configuration for routing systems, bootstrap peers, DNS resolvers, and delegated endpoints in the IPFS Mainnet swarm.">
+    <meta name="description" content="IPFS Mainnet AutoConfig hosts dynamic configuration for routing systems, bootstrap peers, DNS resolvers for special TLDs, and delegated endpoints in the IPFS Mainnet swarm.">
     <style>
         * {
             margin: 0;
@@ -419,7 +419,7 @@
         <section class="hero">
             <div class="container">
                 <h2>Dynamic Configuration<br>for IPFS Mainnet</h2>
-                <p class="lead">Updateable system registry for routing systems, bootstrap peers, DNS resolvers, and delegated endpoints.</p>
+                <p class="lead">Updateable system registry for routing systems, bootstrap peers, special TLD resolvers, and delegated endpoints.</p>
                 <div class="url-input-group">
                     <input type="text" class="url-input" value="https://config.ipfs-mainnet.org/autoconfig.json" readonly>
                     <button class="btn-secondary" onclick="copyUrl()">Copy</button>
@@ -434,7 +434,7 @@
         <section id="overview">
             <div class="container">
                 <h2>Overview</h2>
-                <p>IPFS Mainnet AutoConfig provides a standardized, extensible configuration format for IPFS implementations to discover and configure routing systems, bootstrap peers, DNS resolvers, and delegated endpoints dynamically.</p>
+                <p>IPFS Mainnet AutoConfig provides a standardized, extensible configuration format for IPFS implementations to discover and configure routing systems, bootstrap peers, DNS resolvers for special TLDs, and delegated endpoints dynamically.</p>
 
                 <h3>What is AutoConfig?</h3>
                 <p>This version introduces a system-centric approach that moves away from hardcoded profiles to a flexible registry where routing systems declare their capabilities and endpoints specify which systems they support. This enables:</p>
@@ -460,7 +460,7 @@
         <section id="schema">
             <div class="container">
                 <h2>Configuration Format</h2>
-                <p>The AutoConfig format consists of six main sections that work together to provide comprehensive routing configuration:</p>
+                <p>The AutoConfig format consists of five main sections that work together to provide comprehensive routing configuration:</p>
 
                 <div class="config-sections">
                     <div class="config-section">
@@ -493,9 +493,10 @@
 
                     <div class="config-section">
                         <h4><code>DNSResolvers</code></h4>
-                        <p><strong>Purpose:</strong> DNS-over-HTTPS resolvers organized by effective TLD</p>
-                        <p><strong>Usage:</strong> Resolving non-ICANN domains</p>
+                        <p><strong>Purpose:</strong> DNS-over-HTTPS resolvers for special TLDs</p>
+                        <p><strong>Usage:</strong> Resolving non-ICANN domains like .eth</p>
                         <p><strong>Format:</strong> Maps eTLD to array of DoH endpoints</p>
+                        <p><strong>Note:</strong> Implementations use default resolver from the OS or explicitly choose DoH resolver (e.g. in browsers)</p>
                     </div>
 
                     <div class="config-section">
@@ -604,12 +605,6 @@
                             <td class="api-list">/routing/v1/ipns (R/W)</td>
                         </tr>
                         <tr>
-                            <td><a href="https://datatracker.ietf.org/doc/html/rfc8484" class="system-name">DNS</a></td>
-                            <td><span class="system-type type-both">Native + Delegated</span></td>
-                            <td>DNSLink and non-ICANN domain resolution</td>
-                            <td class="api-list">/dns-query</td>
-                        </tr>
-                        <tr>
                             <td><a href="https://example.com" class="system-name">Example</a></td>
                             <td><span class="system-type type-delegated">Delegated Only</span></td>
                             <td>Demonstrates extensibility pattern</td>
@@ -671,7 +666,8 @@ profile = detectEnvironment() // "browser" or "daemon"
 if autoconfig.Profiles[profile]:
     client.applyPreferences(autoconfig.Profiles[profile])
 
-// 3. Configure DNS resolvers
+// 3. Configure DNS resolvers for special TLDs
+// Note: Implementations use OS default or explicit DoH resolver
 for etld, resolvers in autoconfig.DNSResolvers:
     client.configureDNS(etld, resolvers)</pre>
                 </div>
@@ -764,7 +760,8 @@ for etld, resolvers in autoconfig.DNSResolvers:
         }
     }
     
-    // Configure DNS resolvers
+    // Configure DNS resolvers for special TLDs
+    // Note: Use OS default resolver or explicit DoH for general domains
     for (const [etld, resolvers] of Object.entries(autoconfig.DNSResolvers)) {
         configureDNSResolver(etld, resolvers);
     }

--- a/index.html
+++ b/index.html
@@ -594,7 +594,7 @@
                         <tr>
                             <td><a href="https://example.com" class="system-name">Example</a></td>
                             <td><span class="system-type type-delegated">Delegated Only</span></td>
-                            <td>Demonstrates extensibility pattern</td>
+                            <td>Test system for verifying graceful handling of unknown APIs</td>
                             <td class="api-list">/example/v0/{read,write}</td>
                         </tr>
                     </tbody>

--- a/index.html
+++ b/index.html
@@ -514,6 +514,77 @@
             <div class="container">
                 <h2>Well Known Routing Systems</h2>
                 <p>The registry defines routing systems with their capabilities and access methods:</p>
+                
+                <div class="routing-legend">
+                    <h3>System Routing Types</h3>
+                    <p class="legend-intro">IPFS routing systems can operate in different modes depending on client capabilities and requirements:</p>
+                    <div class="legend-items">
+                        <div class="legend-item">
+                            <span class="legend-icon">🔌</span>
+                            <div class="legend-content">
+                                <span class="legend-badge type-native">Native</span>
+                                <div class="legend-description">
+                                    <strong>Direct implementation within the client</strong><br>
+                                    Examples: DHT participation, local DNS resolver<br>
+                                    <em>Best for: Full nodes, daemons with persistent connectivity</em>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="legend-item">
+                            <span class="legend-icon">🌐</span>
+                            <div class="legend-content">
+                                <span class="legend-badge type-delegated">Delegated</span>
+                                <div class="legend-description">
+                                    <strong>Access via HTTP endpoints</strong><br>
+                                    Used when native support is unavailable or impractical<br>
+                                    <em>Best for: Browsers, mobile apps, resource-constrained environments</em>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="legend-item">
+                            <span class="legend-icon">🔀</span>
+                            <div class="legend-content">
+                                <span class="legend-badge type-both">Hybrid</span>
+                                <div class="legend-description">
+                                    <strong>Both native and delegated support available</strong><br>
+                                    Clients choose based on their capabilities and constraints<br>
+                                    <em>Best for: Flexible implementations that adapt to environment</em>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flow-diagram">
+                    <h3>Implementation Decision Flow</h3>
+                    <div class="flow-container">
+                        <div class="flow-step">
+                            <div class="flow-question">Does your client support native implementation?</div>
+                            <div class="flow-branches">
+                                <div class="flow-branch flow-yes">
+                                    <div class="flow-arrow">YES</div>
+                                    <div class="flow-result native-result">
+                                        <span class="flow-icon">🔌</span>
+                                        <div class="flow-text">
+                                            <strong>Use Native Config</strong>
+                                            <small>Bootstrap peers, direct DHT participation</small>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="flow-branch flow-no">
+                                    <div class="flow-arrow">NO</div>
+                                    <div class="flow-result delegated-result">
+                                        <span class="flow-icon">🌐</span>
+                                        <div class="flow-text">
+                                            <strong>Use Delegated Endpoints</strong>
+                                            <small>HTTP routing via configured endpoints</small>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
                 <style>
                     .systems-table {
@@ -567,6 +638,249 @@
                         font-size: 0.75rem;
                         color: #4a5568;
                     }
+
+                    .routing-legend {
+                        background: #f8f9fa;
+                        border: 1px solid #e2e8f0;
+                        border-radius: 0.75rem;
+                        padding: 1.5rem;
+                        margin: 2rem 0;
+                    }
+
+                    .routing-legend h3 {
+                        margin-bottom: 1rem;
+                        color: #2d3748;
+                        font-size: 1.25rem;
+                    }
+
+                    .legend-intro {
+                        color: #4a5568;
+                        margin-bottom: 1.5rem;
+                        font-style: italic;
+                    }
+
+                    .legend-items {
+                        display: flex;
+                        flex-direction: column;
+                        gap: 1.5rem;
+                    }
+
+                    .legend-item {
+                        display: flex;
+                        align-items: flex-start;
+                        gap: 1rem;
+                        padding: 1rem;
+                        background: #ffffff;
+                        border-radius: 0.5rem;
+                        border: 1px solid #e2e8f0;
+                    }
+
+                    .legend-icon {
+                        font-size: 1.5rem;
+                        width: 2rem;
+                        text-align: center;
+                        flex-shrink: 0;
+                        margin-top: 0.25rem;
+                    }
+
+                    .legend-content {
+                        flex: 1;
+                    }
+
+                    .legend-badge {
+                        display: inline-block;
+                        padding: 0.25rem 0.75rem;
+                        border-radius: 0.25rem;
+                        font-size: 0.875rem;
+                        font-weight: 600;
+                        margin-bottom: 0.5rem;
+                    }
+
+                    .legend-description {
+                        color: #4a5568;
+                        font-size: 0.875rem;
+                        line-height: 1.5;
+                    }
+
+                    .legend-description strong {
+                        color: #2d3748;
+                        display: block;
+                        margin-bottom: 0.25rem;
+                    }
+
+                    .legend-description em {
+                        color: #718096;
+                        font-size: 0.8rem;
+                    }
+
+                    @media (min-width: 1024px) {
+                        .legend-items {
+                            display: grid;
+                            grid-template-columns: repeat(3, 1fr);
+                            gap: 1rem;
+                        }
+                        
+                        .legend-item {
+                            flex-direction: column;
+                            text-align: center;
+                            align-items: center;
+                        }
+                        
+                        .legend-icon {
+                            margin-bottom: 0.5rem;
+                        }
+                    }
+
+                    .flow-diagram {
+                        background: #ffffff;
+                        border: 2px solid #e2e8f0;
+                        border-radius: 0.75rem;
+                        padding: 1.5rem;
+                        margin: 2rem 0;
+                    }
+
+                    .flow-diagram h3 {
+                        margin-bottom: 1.5rem;
+                        color: #2d3748;
+                        font-size: 1.25rem;
+                        text-align: center;
+                    }
+
+                    .flow-container {
+                        display: flex;
+                        justify-content: center;
+                    }
+
+                    .flow-step {
+                        text-align: center;
+                        max-width: 600px;
+                    }
+
+                    .flow-question {
+                        background: #edf2f7;
+                        padding: 1rem;
+                        border-radius: 0.5rem;
+                        font-weight: 600;
+                        color: #2d3748;
+                        margin-bottom: 1.5rem;
+                        border: 2px solid #cbd5e0;
+                    }
+
+                    .flow-branches {
+                        display: flex;
+                        gap: 2rem;
+                        justify-content: center;
+                    }
+
+                    .flow-branch {
+                        flex: 1;
+                        max-width: 200px;
+                    }
+
+                    .flow-arrow {
+                        background: #4a5568;
+                        color: white;
+                        padding: 0.5rem 1rem;
+                        border-radius: 1rem;
+                        font-weight: 600;
+                        font-size: 0.875rem;
+                        margin-bottom: 1rem;
+                        display: inline-block;
+                    }
+
+                    .flow-result {
+                        padding: 1rem;
+                        border-radius: 0.5rem;
+                        border: 2px solid;
+                        display: flex;
+                        align-items: center;
+                        gap: 0.75rem;
+                        text-align: left;
+                    }
+
+                    .native-result {
+                        background: #f0fff4;
+                        border-color: #68d391;
+                    }
+
+                    .delegated-result {
+                        background: #f0f9ff;
+                        border-color: #63b3ed;
+                    }
+
+                    .flow-icon {
+                        font-size: 1.5rem;
+                        flex-shrink: 0;
+                    }
+
+                    .flow-text strong {
+                        display: block;
+                        color: #2d3748;
+                        margin-bottom: 0.25rem;
+                    }
+
+                    .flow-text small {
+                        color: #4a5568;
+                        font-size: 0.75rem;
+                    }
+
+                    @media (max-width: 640px) {
+                        .flow-branches {
+                            flex-direction: column;
+                            gap: 1rem;
+                        }
+                        
+                        .flow-branch {
+                            max-width: none;
+                        }
+                    }
+
+                    .routing-card-icon {
+                        font-size: 2.5rem;
+                        margin-bottom: 1rem;
+                    }
+
+                    .routing-card-native {
+                        background: linear-gradient(135deg, #f0fff4 0%, #ffffff 100%);
+                        border-color: #68d391;
+                    }
+
+                    .routing-card-delegated {
+                        background: linear-gradient(135deg, #f0f9ff 0%, #ffffff 100%);
+                        border-color: #63b3ed;
+                    }
+
+                    .routing-card-both {
+                        background: linear-gradient(135deg, #fffbf0 0%, #ffffff 100%);
+                        border-color: #f6e05e;
+                    }
+
+                    .code-block-native {
+                        border-left: 4px solid #68d391;
+                    }
+
+                    .code-block-delegated {
+                        border-left: 4px solid #63b3ed;
+                    }
+
+                    .code-block-mixed {
+                        border-left: 4px solid #f6e05e;
+                    }
+
+                    .code-header-native::before {
+                        content: "🔌 ";
+                        color: #38a169;
+                    }
+
+                    .code-header-delegated::before {
+                        content: "🌐 ";
+                        color: #3182ce;
+                    }
+
+                    .code-header-mixed::before {
+                        content: "🔀 ";
+                        color: #d69e2e;
+                    }
                 </style>
 
                 <table class="systems-table">
@@ -581,40 +895,25 @@
                     <tbody>
                         <tr>
                             <td><a href="https://github.com/ipfs/specs/pull/497" class="system-name">AminoDHT</a></td>
-                            <td><span class="system-type type-both">Native + Delegated</span></td>
+                            <td><span class="system-type type-both">🔀 Native + Delegated</span></td>
                             <td>P2P content and peer routing via Kademlia DHT</td>
                             <td class="api-list">/routing/v1/{providers,peers,ipns} (R/W for ipns)</td>
                         </tr>
                         <tr>
                             <td><a href="https://cid.contact" class="system-name">IPNI</a></td>
-                            <td><span class="system-type type-delegated">Delegated Only</span></td>
+                            <td><span class="system-type type-delegated">🌐 Delegated Only</span></td>
                             <td>Fast content discovery from large storage providers</td>
                             <td class="api-list">/routing/v1/providers</td>
                         </tr>
                         <tr>
                             <td><a href="https://example.com" class="system-name">Example</a></td>
-                            <td><span class="system-type type-delegated">Delegated Only</span></td>
+                            <td><span class="system-type type-delegated">🌐 Delegated Only</span></td>
                             <td>Test system for verifying graceful handling of unknown APIs</td>
                             <td class="api-list">/example/v0/{read,write}</td>
                         </tr>
                     </tbody>
                 </table>
 
-                <h3>System Types</h3>
-                <div class="feature-grid">
-                    <div class="feature-card">
-                        <h4>🟢 Native</h4>
-                        <p>Direct implementation within the client (e.g., DHT participation, local DNS resolver)</p>
-                    </div>
-                    <div class="feature-card">
-                        <h4>🔵 Delegated</h4>
-                        <p>Access via HTTP endpoints when native support is unavailable or impractical</p>
-                    </div>
-                    <div class="feature-card">
-                        <h4>🟡 Both</h4>
-                        <p>Systems that can operate either natively or through delegation based on client capabilities</p>
-                    </div>
-                </div>
 
                 <h3>Adding New Systems</h3>
                 <p>The schema supports gradual ecosystem evolution: add systems to the registry with their API paths, update endpoints to declare support, and existing clients will ignore unknown APIs while new clients can leverage them immediately.</p>
@@ -634,8 +933,8 @@
                 <h3>API Versioning Strategy</h3>
                 <p>Delegated utility servers can support multiple API versions simultaneously:</p>
 
-                <div class="code-block">
-                    <div class="code-header">API Version Evolution Example</div>
+                <div class="code-block code-block-delegated">
+                    <div class="code-header code-header-delegated">API Version Evolution Example</div>
                     <pre>{
   "DelegatedEndpoints": {
     "https://future-endpoint.example": {
@@ -682,8 +981,8 @@
                 </div>
 
                 <h4>Processing Algorithm</h4>
-                <div class="code-block">
-                    <div class="code-header">Pseudo-code</div>
+                <div class="code-block code-block-mixed">
+                    <div class="code-header code-header-mixed">Pseudo-code</div>
                     <pre>// 1. Check SystemRegistry for available routing systems
 for system in autoconfig.SystemRegistry:
     if client.supportsNative(system):
@@ -707,8 +1006,8 @@ for etld, resolvers in autoconfig.DNSResolvers:
 
                 <h4>Example Implementation</h4>
 
-                <div class="code-block">
-                    <div class="code-header">JavaScript Client Example</div>
+                <div class="code-block code-block-mixed">
+                    <div class="code-header code-header-mixed">JavaScript Client Example</div>
                     <pre>async function configureIPFS() {
     // Fetch AutoConfig
     const response = await fetch('https://config.ipfs-mainnet.org/autoconfig.json');
@@ -764,7 +1063,7 @@ for etld, resolvers in autoconfig.DNSResolvers:
                             <li>Implement aggressive caching</li>
                             <li>Consider service worker integration</li>
                         </ul>
-                        <div class="code-block" style="margin-top: 1rem;">
+                        <div class="code-block code-block-delegated" style="margin-top: 1rem;">
                             <pre style="text-align: left;">// Browser-optimized configuration
 const browserDefaults = {
     preferDelegated: ['AminoDHT', 'IPNI'],
@@ -783,7 +1082,7 @@ const browserDefaults = {
                             <li>Enable both TCP and QUIC transports</li>
                             <li>Participate in content providing (native AminoDHT only)</li>
                         </ul>
-                        <div class="code-block" style="margin-top: 1rem;">
+                        <div class="code-block code-block-mixed" style="margin-top: 1rem;">
                             <pre style="text-align: left;">// Daemon-optimized configuration
 const daemonDefaults = {
     preferNative: ['AminoDHT'],
@@ -803,7 +1102,7 @@ const daemonDefaults = {
                             <li>Optional native DHT on WiFi</li>
                             <li>Aggressive connection pruning</li>
                         </ul>
-                        <div class="code-block" style="margin-top: 1rem;">
+                        <div class="code-block code-block-mixed" style="margin-top: 1rem;">
                             <pre style="text-align: left;">// Mobile-optimized configuration
 const mobileDefaults = {
     preferDelegated: ['AminoDHT', 'IPNI'],
@@ -817,8 +1116,8 @@ const mobileDefaults = {
                 <h4>Platform-Specific Considerations</h4>
                 <p>Implementers should make these decisions at build time based on their target platform rather than reading them from the autoconfig. The autoconfig provides the <em>what</em> (available systems and endpoints), while your implementation decides the <em>how</em> (native vs delegated routing).</p>
 
-                <div class="code-block">
-                    <div class="code-header">Implementation Decision Tree</div>
+                <div class="code-block code-block-mixed">
+                    <div class="code-header code-header-mixed">Implementation Decision Tree</div>
                     <pre>// Instead of reading profiles from autoconfig, hard-code platform decisions:
 function getRoutingStrategy() {
     if (typeof window !== 'undefined' && !window.require) {


### PR DESCRIPTION
This aims to incorporate feedback/discussions from #1 in a way that that does not require clients to hardcode any new mapping between HTTP endpoints and features.

This format is more open-ended, can serve as a discovery mechanism that allows IPFS Mainnet to deploy novel routing systems (e.g., new DHT variants, blockchain-based routing) immediately through well-known HTTP endpoints while implementations gradually add native support

cc @aschmahmann for feedback

---- 

BREAKING CHANGE: Schema v4 introduces system-centric configuration

Rationale:
- Moves from static profile-based config to dynamic system registry
- Enables gradual ecosystem evolution without breaking existing clients
- Allows new routing systems to be introduced via HTTP adapters
- Introduces more clear separation between native and delegated routing

Highlights:
- SystemRegistry defines well known routing systems with capabilities
- Delegated HTTP endpoints declare which systems and APIs they provide
- Clients ignore unknown APIs (not entire systems) for extensibility
- Profiles become optional hints rather than rigid configurations
- API versioning moved to endpoint level for flexibility
