### PR TITLE
refactor: rename to autoconf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# IPFS Mainnet AutoConfig
+# IPFS Mainnet AutoConf
 
-Dynamic network defaults for IPFS Mainnet served at https://config.ipfs-mainnet.org/autoconfig.json
+Dynamic network defaults for IPFS Mainnet served at https://config.ipfs-mainnet.org/autoconf.json
 
 Maintained by [🚢 Shipyard](https://ipshipyard.com/) • [IPFS Docs](https://docs.ipfs.tech/) • [Mainnet Glossary](https://docs.ipfs.tech/concepts/glossary/#mainnet)

--- a/autoconf.json
+++ b/autoconf.json
@@ -1,10 +1,10 @@
 {
   "AutoConfVersion": 2025080401,
   "AutoConfSchema": 5,
-  "CacheTTL": 86400,
+  "AutoConfTTL": 86400,
   "SystemRegistry": {
     "AminoDHT": {
-      "URL": "https://github.com/ipfs/specs/pull/497",
+      "InfoURL": "https://github.com/ipfs/specs/pull/497",
       "Description": "Public DHT swarm that implements the IPFS Kademlia DHT specification under protocol identifier /ipfs/kad/1.0.0",
       "NativeConfig": {
         "Bootstrap": [
@@ -29,7 +29,7 @@
       }
     },
     "IPNI": {
-      "URL": "https://cid.contact",
+      "InfoURL": "https://cid.contact",
       "Description": "Network Indexer - content routing database for large storage providers",
       "DelegatedConfig": {
         "Read": [
@@ -39,7 +39,7 @@
       }
     },
     "Example": {
-      "URL": "https://example.com",
+      "InfoURL": "https://example.com",
       "Description": "Test system for implementers to verify graceful handling of unknown systems and APIs. Production clients MUST ignore this system and its /example/* endpoints without errors.",
       "DelegatedConfig": {
         "Read": [

--- a/autoconf.json
+++ b/autoconf.json
@@ -1,6 +1,6 @@
 {
   "AutoConfVersion": 2025080401,
-  "AutoConfSchema": 5,
+  "AutoConfSchema": 1,
   "AutoConfTTL": 86400,
   "SystemRegistry": {
     "AminoDHT": {

--- a/autoconf.json
+++ b/autoconf.json
@@ -1,6 +1,6 @@
 {
-  "AutoConfigVersion": 2025072901,
-  "AutoConfigSchema": 4,
+  "AutoConfVersion": 2025080401,
+  "AutoConfSchema": 5,
   "CacheTTL": 86400,
   "SystemRegistry": {
     "AminoDHT": {

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>🧭 IPFS Mainnet AutoConfig - Dynamic Configuration for IPFS Mainnet Swarm</title>
-    <meta name="description" content="IPFS Mainnet AutoConfig hosts dynamic configuration for routing systems, bootstrap peers, DNS resolvers for special TLDs, and delegated endpoints in the IPFS Mainnet swarm.">
+    <title>🧭 IPFS Mainnet AutoConf - Dynamic Configuration for IPFS Mainnet Swarm</title>
+    <meta name="description" content="IPFS Mainnet AutoConf hosts dynamic configuration for routing systems, bootstrap peers, DNS resolvers for special TLDs, and delegated endpoints in the IPFS Mainnet swarm.">
     <style>
         * {
             margin: 0;
@@ -405,7 +405,7 @@
     </div>
     <header>
         <nav class="container">
-            <h1>🧭 IPFS Mainnet AutoConfig</h1>
+            <h1>🧭 IPFS Mainnet AutoConf</h1>
             <ul class="nav-links">
                 <li><a href="#overview">Overview</a></li>
                 <li><a href="#schema">Format</a></li>
@@ -421,11 +421,11 @@
                 <h2>Dynamic Configuration<br>for IPFS Mainnet</h2>
                 <p class="lead">Updateable system registry for routing systems, bootstrap peers, special TLD resolvers, and delegated endpoints.</p>
                 <div class="url-input-group">
-                    <input type="text" class="url-input" value="https://config.ipfs-mainnet.org/autoconfig.json" readonly>
+                    <input type="text" class="url-input" value="https://config.ipfs-mainnet.org/autoconf.json" readonly>
                     <button class="btn-secondary" onclick="copyUrl()">Copy</button>
                     <div class="button-group">
-                        <a href="/autoconfig.json" class="btn" target="_blank">View</a>
-                        <a href="/autoconfig.json" class="btn" download target="_blank">Download</a>
+                        <a href="/autoconf.json" class="btn" target="_blank">View</a>
+                        <a href="/autoconf.json" class="btn" download target="_blank">Download</a>
                     </div>
                 </div>
             </div>
@@ -434,9 +434,9 @@
         <section id="overview">
             <div class="container">
                 <h2>Overview</h2>
-                <p>IPFS Mainnet AutoConfig provides a standardized, extensible configuration format for IPFS implementations to discover and configure routing systems, bootstrap peers, DNS resolvers for special TLDs, and delegated endpoints dynamically.</p>
+                <p>IPFS Mainnet AutoConf provides a standardized, extensible configuration format for IPFS implementations to discover and configure routing systems, bootstrap peers, DNS resolvers for special TLDs, and delegated endpoints dynamically.</p>
 
-                <h3>What is AutoConfig?</h3>
+                <h3>What is AutoConf?</h3>
                 <p>This version introduces a system-centric approach that moves away from hardcoded profiles to a flexible registry where routing systems declare their capabilities and endpoints specify which systems they support. This enables:</p>
                 
                 <ul>
@@ -459,18 +459,18 @@
         <section id="schema">
             <div class="container">
                 <h2>Configuration Format</h2>
-                <p>The AutoConfig format consists of the following sections that work together to provide comprehensive routing configuration:</p>
+                <p>The AutoConf format consists of the following sections that work together to provide comprehensive routing configuration:</p>
 
                 <div class="config-sections">
                     <div class="config-section">
-                        <h4><code>AutoConfigVersion</code></h4>
+                        <h4><code>AutoConfVersion</code></h4>
                         <p><strong>Purpose:</strong> Timestamp-based version identifier (YYYYMMDDNN format), similar to DNS SOA sequence numbers</p>
                         <p><strong>Usage:</strong> Clients use this to determine if they have the latest configuration</p>
                         <p><strong>Example:</strong> <code>2025072801</code> (January 28, 2025, version 01)</p>
                     </div>
 
                     <div class="config-section">
-                        <h4><code>AutoConfigSchema</code></h4>
+                        <h4><code>AutoConfSchema</code></h4>
                         <p><strong>Purpose:</strong> Schema version number for breaking changes</p>
                         <p><strong>Usage:</strong> Allows clients to handle different config formats</p>
                         <p><strong>Current:</strong> <code>4</code></p>
@@ -961,7 +961,7 @@
                 <div class="status-banner">
                     <div>
                         <h3>🚧 Work in Progress</h3>
-                        <p>IPFS Mainnet AutoConfig support is under active development for integration into IPFS implementation ecosystems:</p>
+                        <p>IPFS Mainnet AutoConf support is under active development for integration into IPFS implementation ecosystems:</p>
                         <div class="ecosystem-section">
                             <h4><a href="https://github.com/ipfs/boxo">Boxo</a> (Go ecosystem)</h4>
                             <ul>
@@ -984,13 +984,13 @@
                 <div class="code-block code-block-mixed">
                     <div class="code-header code-header-mixed">Pseudo-code</div>
                     <pre>// 1. Check SystemRegistry for available routing systems
-for system in autoconfig.SystemRegistry:
+for system in autoconf.SystemRegistry:
     if client.supportsNative(system):
         // Use native implementation with NativeConfig
-        client.configureNative(system, autoconfig.SystemRegistry[system].NativeConfig)
+        client.configureNative(system, autoconf.SystemRegistry[system].NativeConfig)
     else:
         // Use delegated routing via HTTP endpoints
-        for endpoint in autoconfig.DelegatedEndpoints:
+        for endpoint in autoconf.DelegatedEndpoints:
             if system in endpoint.Systems:
                 // Filter to only APIs this client recognizes
                 supportedReadAPIs = client.filterKnownAPIs(endpoint.Read)
@@ -1000,7 +1000,7 @@ for system in autoconfig.SystemRegistry:
 
 // 2. Configure DNS resolvers for special TLDs
 // Note: Implementations use OS default or explicit DoH resolver
-for etld, resolvers in autoconfig.DNSResolvers:
+for etld, resolvers in autoconf.DNSResolvers:
     client.configureDNS(etld, resolvers)</pre>
                 </div>
 
@@ -1009,15 +1009,15 @@ for etld, resolvers in autoconfig.DNSResolvers:
                 <div class="code-block code-block-mixed">
                     <div class="code-header code-header-mixed">JavaScript Client Example</div>
                     <pre>async function configureIPFS() {
-    // Fetch AutoConfig
-    const response = await fetch('https://config.ipfs-mainnet.org/autoconfig.json');
-    const autoconfig = await response.json();
+    // Fetch AutoConf
+    const response = await fetch('https://config.ipfs-mainnet.org/autoconf.json');
+    const autoconf = await response.json();
     
     // Cache for minimum of 24 hours or CacheTTL from config
     const maxCacheSeconds = 24 * 60 * 60; // 24 hours
-    const cacheTTL = Math.min(maxCacheSeconds, autoconfig.CacheTTL || maxCacheSeconds);
-    localStorage.setItem('ipfs-autoconfig', JSON.stringify({
-        data: autoconfig,
+    const cacheTTL = Math.min(maxCacheSeconds, autoconf.CacheTTL || maxCacheSeconds);
+    localStorage.setItem('ipfs-autoconf', JSON.stringify({
+        data: autoconf,
         expires: Date.now() + (cacheTTL * 1000)
     }));
     
@@ -1025,7 +1025,7 @@ for etld, resolvers in autoconfig.DNSResolvers:
     const nativeSystems = ['AminoDHT']; // This client has native DHT support
     
     // Configure routing systems
-    for (const [systemName, systemConfig] of Object.entries(autoconfig.SystemRegistry)) {
+    for (const [systemName, systemConfig] of Object.entries(autoconf.SystemRegistry)) {
         if (nativeSystems.includes(systemName)) {
             // Use native implementation
             if (systemName === 'AminoDHT' && canRunDHT()) {
@@ -1033,7 +1033,7 @@ for etld, resolvers in autoconfig.DNSResolvers:
             }
         } else {
             // Delegate to HTTP endpoints for unsupported systems
-            for (const [url, endpoint] of Object.entries(autoconfig.DelegatedEndpoints)) {
+            for (const [url, endpoint] of Object.entries(autoconf.DelegatedEndpoints)) {
                 if (endpoint.Systems.includes(systemName)) {
                     configureDelegatedRouting(systemName, url, endpoint);
                 }
@@ -1043,7 +1043,7 @@ for etld, resolvers in autoconfig.DNSResolvers:
     
     // Configure DNS resolvers for special TLDs
     // Note: Use OS default resolver or explicit DoH for general domains
-    for (const [etld, resolvers] of Object.entries(autoconfig.DNSResolvers)) {
+    for (const [etld, resolvers] of Object.entries(autoconf.DNSResolvers)) {
         configureDNSResolver(etld, resolvers);
     }
 }</pre>
@@ -1114,11 +1114,11 @@ const mobileDefaults = {
                 </div>
 
                 <h4>Platform-Specific Considerations</h4>
-                <p>Implementers should make these decisions at build time based on their target platform rather than reading them from the autoconfig. The autoconfig provides the <em>what</em> (available systems and endpoints), while your implementation decides the <em>how</em> (native vs delegated routing).</p>
+                <p>Implementers should make these decisions at build time based on their target platform rather than reading them from the autoconf. The autoconf provides the <em>what</em> (available systems and endpoints), while your implementation decides the <em>how</em> (native vs delegated routing).</p>
 
                 <div class="code-block code-block-mixed">
                     <div class="code-header code-header-mixed">Implementation Decision Tree</div>
-                    <pre>// Instead of reading profiles from autoconfig, hard-code platform decisions:
+                    <pre>// Instead of reading profiles from autoconf, hard-code platform decisions:
 function getRoutingStrategy() {
     if (typeof window !== 'undefined' && !window.require) {
         // Browser environment
@@ -1133,7 +1133,7 @@ function getRoutingStrategy() {
 }</pre>
                 </div>
 
-                <p>This approach provides clearer separation between configuration data (what services are available) and implementation decisions (how to use those services), making both the autoconfig and implementations simpler and more maintainable.</p>
+                <p>This approach provides clearer separation between configuration data (what services are available) and implementation decisions (how to use those services), making both the autoconf and implementations simpler and more maintainable.</p>
             </div>
         </section>
 

--- a/index.html
+++ b/index.html
@@ -473,11 +473,11 @@
                         <h4><code>AutoConfSchema</code></h4>
                         <p><strong>Purpose:</strong> Schema version number for breaking changes</p>
                         <p><strong>Usage:</strong> Allows clients to handle different config formats</p>
-                        <p><strong>Current:</strong> <code>4</code></p>
+                        <p><strong>Current:</strong> <code>5</code></p>
                     </div>
 
                     <div class="config-section">
-                        <h4><code>CacheTTL</code></h4>
+                        <h4><code>AutoConfTTL</code></h4>
                         <p><strong>Purpose:</strong> Cache duration in seconds</p>
                         <p><strong>Usage:</strong> A hint that clients should cache config for this duration (capped at 24 hours maximum), clients can override this hint but only as explicit user opt-in</p>
                         <p><strong>Default:</strong> <code>86400</code> (24 hours)</p>
@@ -486,7 +486,7 @@
                     <div class="config-section">
                         <h4><code>SystemRegistry</code></h4>
                         <p><strong>Purpose:</strong> Discovery registry of all routing systems</p>
-                        <p><strong>Contains:</strong> System metadata, native configuration, and delegated API capabilities</p>
+                        <p><strong>Contains:</strong> Link to documentation, native configuration, and delegated API capabilities</p>
                         <p><strong>Usage:</strong> Clients check here to understand system capabilities</p>
                     </div>
 

--- a/index.html
+++ b/index.html
@@ -473,7 +473,7 @@
                         <h4><code>AutoConfSchema</code></h4>
                         <p><strong>Purpose:</strong> Schema version number for breaking changes</p>
                         <p><strong>Usage:</strong> Allows clients to handle different config formats</p>
-                        <p><strong>Current:</strong> <code>5</code></p>
+                        <p><strong>Current:</strong> <code>1</code></p>
                     </div>
 
                     <div class="config-section">


### PR DESCRIPTION
Based on initial feedback (thx @2color):
- easier to pronounce
- clarify purpose of the URL in SystemRegistry
- make it clear TTL is relatd to autoconf system
- since we renamed schema field, also resetting counter to 1